### PR TITLE
fix home viewmodel unit tests and add transaction viewmodel tests.

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -95,6 +95,7 @@ dependencies {
     testRuntimeOnly(libs.junit.platform)
     testImplementation(libs.junit.jupiter.api)
     testImplementation(libs.junit.jupiter.engine)
+    testImplementation(libs.turbineDependency.turbine)
 
     androidTestImplementation(libs.androidx.espresso.core)
     androidTestImplementation(platform(libs.androidx.compose.bom))

--- a/app/src/main/java/com/example/nebulatest/core/TimeProvider.kt
+++ b/app/src/main/java/com/example/nebulatest/core/TimeProvider.kt
@@ -1,0 +1,8 @@
+package com.example.nebulatest.core
+
+import org.koin.core.annotation.Factory
+
+@Factory
+class TimeProvider {
+    fun getCurrentTimeMillis() = System.currentTimeMillis()
+}

--- a/app/src/main/java/com/example/nebulatest/features/exchange/rate/data/remote/ExchangeRateRemoteRepository.kt
+++ b/app/src/main/java/com/example/nebulatest/features/exchange/rate/data/remote/ExchangeRateRemoteRepository.kt
@@ -1,5 +1,7 @@
 package com.example.nebulatest.features.exchange.rate.data.remote
 
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import org.koin.core.annotation.Single
 
 @Single
@@ -7,12 +9,14 @@ class ExchangeRateRemoteRepository(private val exchangeRateService: ExchangeRate
 
     suspend fun getExchangeRate(): Result<Pair<Double, Long>> {
         return try {
-            val response = exchangeRateService.getExchangeRate()
-            if (response.isSuccessful) {
-                Result.success(response.body()?.let { it.data.priceUsd to it.timestamp }
-                    ?: throw Exception("No data found"))
-            } else {
-                Result.failure(Exception(response.message()))
+            withContext(Dispatchers.IO) {
+                val response = exchangeRateService.getExchangeRate()
+                if (response.isSuccessful) {
+                    Result.success(response.body()?.let { it.data.priceUsd to it.timestamp }
+                        ?: throw Exception("No data found"))
+                } else {
+                    Result.failure(Exception(response.message()))
+                }
             }
         } catch (e: Exception) {
             Result.failure(e)

--- a/app/src/main/java/com/example/nebulatest/features/exchange/rate/domain/GetExchangeRateUseCase.kt
+++ b/app/src/main/java/com/example/nebulatest/features/exchange/rate/domain/GetExchangeRateUseCase.kt
@@ -2,8 +2,6 @@ package com.example.nebulatest.features.exchange.rate.domain
 
 import com.example.nebulatest.features.exchange.rate.data.local.ExchangeRateLocalRepository
 import com.example.nebulatest.features.exchange.rate.data.remote.ExchangeRateRemoteRepository
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
 import org.koin.core.annotation.Factory
 
 @Factory
@@ -12,20 +10,18 @@ class GetExchangeRateUseCase(
     private val exchangeRateLocalRepository: ExchangeRateLocalRepository
 ) {
     suspend operator fun invoke(): Result<Double> {
-        return withContext(Dispatchers.IO) {
-            val latestExchangeRate = exchangeRateLocalRepository.getLatestExchangeRate()
-            if (latestExchangeRate == null || System.currentTimeMillis() > latestExchangeRate.timestamp + 3600000) {
-                val newExchangeRateResult = exchangeRateRemoteRepository.getExchangeRate()
-                val newExchangeRate = newExchangeRateResult.getOrNull()
-                if (newExchangeRateResult.isSuccess && newExchangeRate != null) {
-                    exchangeRateLocalRepository.setLatestExchangeRate(
-                        newExchangeRate.second, newExchangeRate.first
-                    )
-                }
-                newExchangeRateResult.map { it.first }
-            } else {
-                Result.success(latestExchangeRate.price)
+        val latestExchangeRate = exchangeRateLocalRepository.getLatestExchangeRate()
+        return if (latestExchangeRate == null || System.currentTimeMillis() > latestExchangeRate.timestamp + 3600000) {
+            val newExchangeRateResult = exchangeRateRemoteRepository.getExchangeRate()
+            val newExchangeRate = newExchangeRateResult.getOrNull()
+            if (newExchangeRateResult.isSuccess && newExchangeRate != null) {
+                exchangeRateLocalRepository.setLatestExchangeRate(
+                    newExchangeRate.second, newExchangeRate.first
+                )
             }
+            newExchangeRateResult.map { it.first }
+        } else {
+            Result.success(latestExchangeRate.price)
         }
     }
 }

--- a/app/src/main/java/com/example/nebulatest/features/transaction/data/local/TransactionLocalRepository.kt
+++ b/app/src/main/java/com/example/nebulatest/features/transaction/data/local/TransactionLocalRepository.kt
@@ -15,7 +15,6 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.withContext
 import org.koin.core.annotation.Factory
 
 @Factory
@@ -24,17 +23,13 @@ class TransactionLocalRepository(private val transactionDao: TransactionDao) {
     private var pagingSource: PagingSource<Int, TransactionEntity>? = null
 
     suspend fun addIncome(income: IncomeModel) {
-        withContext(Dispatchers.IO) {
-            transactionDao.insertTransaction(income.toTransactionEntity())
-            pagingSource?.invalidate()
-        }
+        transactionDao.insertTransaction(income.toTransactionEntity())
+        pagingSource?.invalidate()
     }
 
     suspend fun addExpense(expanse: ExpanseModel) {
-        withContext(Dispatchers.IO) {
-            transactionDao.insertTransaction(expanse.toTransactionEntity())
-            pagingSource?.invalidate()
-        }
+        transactionDao.insertTransaction(expanse.toTransactionEntity())
+        pagingSource?.invalidate()
     }
 
     fun getTransactionsPaged(): Flow<PagingData<TransactionLocalModel>> {

--- a/app/src/main/java/com/example/nebulatest/features/transaction/model/ExpanseModel.kt
+++ b/app/src/main/java/com/example/nebulatest/features/transaction/model/ExpanseModel.kt
@@ -5,7 +5,7 @@ import com.example.nebulatest.features.transaction.model.local.TransactionEntity
 data class ExpanseModel(
     val amount: Double,
     val category: TransactionCategory,
-    val timestamp: Long = System.currentTimeMillis()
+    val timestamp: Long
 )
 
 fun ExpanseModel.toTransactionEntity() = TransactionEntity(

--- a/app/src/main/java/com/example/nebulatest/features/transaction/model/IncomeModel.kt
+++ b/app/src/main/java/com/example/nebulatest/features/transaction/model/IncomeModel.kt
@@ -4,7 +4,7 @@ import com.example.nebulatest.features.transaction.model.local.TransactionEntity
 
 data class IncomeModel(
     val amount: Double,
-    val timestamp: Long = System.currentTimeMillis()
+    val timestamp: Long
 )
 
 fun IncomeModel.toTransactionEntity() = TransactionEntity(

--- a/app/src/main/java/com/example/nebulatest/ui/screens/transaction/TransactionViewModel.kt
+++ b/app/src/main/java/com/example/nebulatest/ui/screens/transaction/TransactionViewModel.kt
@@ -2,11 +2,11 @@ package com.example.nebulatest.ui.screens.transaction
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.example.nebulatest.core.TimeProvider
 import com.example.nebulatest.features.balance.data.BalanceLocalDataSource
 import com.example.nebulatest.features.transaction.data.local.TransactionLocalRepository
 import com.example.nebulatest.features.transaction.model.ExpanseModel
 import com.example.nebulatest.features.transaction.model.TransactionCategory
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -26,7 +26,8 @@ sealed class TransactionEvents {
 @Factory
 class TransactionViewModel(
     private val transactionLocalRepository: TransactionLocalRepository,
-    private val balanceLocalDataSource: BalanceLocalDataSource
+    private val balanceLocalDataSource: BalanceLocalDataSource,
+    private val timeProvider: TimeProvider
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(TransactionState())
@@ -36,13 +37,14 @@ class TransactionViewModel(
     val events = _events.receiveAsFlow()
 
     fun addExpanse(amountText: String) {
-        viewModelScope.launch(Dispatchers.IO) {
+        viewModelScope.launch {
             val amount = amountText.toDoubleOrNull()
             if (amount != null) {
                 transactionLocalRepository.addExpense(
                     ExpanseModel(
                         amount,
-                        _uiState.value.selectedCategory
+                        _uiState.value.selectedCategory,
+                        timeProvider.getCurrentTimeMillis()
                     )
                 )
                 balanceLocalDataSource.updateBalance(-amount)

--- a/app/src/test/java/com/example/nebulatest/TransactionViewModelUnitTest.kt
+++ b/app/src/test/java/com/example/nebulatest/TransactionViewModelUnitTest.kt
@@ -3,16 +3,15 @@ package com.example.nebulatest
 import app.cash.turbine.test
 import com.example.nebulatest.core.TimeProvider
 import com.example.nebulatest.features.balance.data.BalanceLocalDataSource
-import com.example.nebulatest.features.exchange.rate.domain.GetExchangeRateUseCase
 import com.example.nebulatest.features.transaction.data.local.TransactionLocalRepository
-import com.example.nebulatest.features.transaction.model.IncomeModel
-import com.example.nebulatest.ui.screens.home.HomeEvents
-import com.example.nebulatest.ui.screens.home.HomeViewModel
+import com.example.nebulatest.features.transaction.model.ExpanseModel
+import com.example.nebulatest.features.transaction.model.TransactionCategory
+import com.example.nebulatest.ui.screens.transaction.TransactionEvents
+import com.example.nebulatest.ui.screens.transaction.TransactionViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.flow.emptyFlow
-import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
@@ -21,81 +20,82 @@ import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertNotNull
 import org.mockito.Mockito
 import org.mockito.Mockito.mock
+import org.mockito.MockitoAnnotations
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 
 @OptIn(ExperimentalCoroutinesApi::class)
-class HomeViewModelUnitTest {
+class TransactionViewModelUnitTest {
     private val currentTime = 12L
 
-    private val getExchangeRateUseCase: GetExchangeRateUseCase = mock()
+    private lateinit var viewModel: TransactionViewModel
+
     private val transactionLocalRepository: TransactionLocalRepository = mock()
     private val balanceLocalDataSource: BalanceLocalDataSource = mock()
     private val timeProvider: TimeProvider = mock()
 
-    private lateinit var viewModel: HomeViewModel
     private val testDispatcher = StandardTestDispatcher()
 
     @BeforeEach
-    fun setup() = runTest(testDispatcher) {
+    fun setup() = runTest {
+        MockitoAnnotations.openMocks(this)
 
         Dispatchers.setMain(testDispatcher)
 
-        whenever(getExchangeRateUseCase.invoke()).thenReturn(Result.success(8432423423.633265))
-        whenever(balanceLocalDataSource.getBalance()).thenReturn(flowOf(1.4636546))
-        whenever(transactionLocalRepository.getTransactionsPaged()).thenReturn(emptyFlow())
         whenever(timeProvider.getCurrentTimeMillis()).thenReturn(currentTime)
 
-        viewModel = HomeViewModel(
-            getExchangeRateUseCase,
+        viewModel = TransactionViewModel(
             transactionLocalRepository,
             balanceLocalDataSource,
             timeProvider
         )
 
+        verifyNoMoreInteractions()
+    }
+
+    @Test
+    fun `add expanse and amount is not null test`() = runTest(UnconfinedTestDispatcher()) {
+        val amountText = "0.23"
+        val amount = 0.23
+
+        viewModel.addExpanse(amountText)
+
         advanceUntilIdle()
 
-        verify(balanceLocalDataSource).getBalance()
-        verify(getExchangeRateUseCase).invoke()
-        verify(transactionLocalRepository).getTransactionsPaged()
+        assertNotNull(amount)
+        verify(transactionLocalRepository).addExpense(
+            ExpanseModel(amount, viewModel.uiState.value.selectedCategory, currentTime)
+        )
+        verify(balanceLocalDataSource).updateBalance(-amount)
 
         verifyNoMoreInteractions()
     }
 
     @Test
-    fun `addIncome and income is null test`() = runTest {
-        val textIncome = "0,23,66"
+    fun `add expanse and amount is null test`() = runTest {
+        val amountText = "0,23,66"
 
         viewModel.events.test {
-            viewModel.addIncome(textIncome)
-            assertEquals(HomeEvents.ShowErrorSnackbar, awaitItem())
+            viewModel.addExpanse(amountText)
+            assertEquals(TransactionEvents.ShowErrorSnackbar, awaitItem())
         }
 
         verifyNoMoreInteractions()
     }
 
     @Test
-    fun `addIncome and income is not null test`() = runTest {
-        val textIncome = "0.23"
-        val income = 0.23
-
-        viewModel.addIncome(textIncome)
-
-        advanceUntilIdle()
-
-        verify(transactionLocalRepository).addIncome(IncomeModel(income, currentTime))
-        verify(balanceLocalDataSource).updateBalance(income)
+    fun `set category test`() {
+        viewModel.selectCategory(TransactionCategory.TAXI)
+        assertEquals(viewModel.uiState.value.selectedCategory, TransactionCategory.TAXI)
 
         verifyNoMoreInteractions()
     }
 
-
     private fun verifyNoMoreInteractions() {
-        Mockito.verifyNoMoreInteractions(
-            transactionLocalRepository, balanceLocalDataSource, getExchangeRateUseCase
-        )
+        Mockito.verifyNoMoreInteractions(transactionLocalRepository, balanceLocalDataSource)
     }
 
     @AfterEach
@@ -103,4 +103,3 @@ class HomeViewModelUnitTest {
         Dispatchers.resetMain()
     }
 }
-

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,6 +6,7 @@ espressoCore = "3.6.1"
 mockitoVersion = "5.15.2"
 mockitoInlineVersion = "5.2.0"
 mockitoKotlinVersion = "5.4.0"
+turbineVersion = "1.0.0"
 
 kotlin = "2.0.0"
 coreKtx = "1.15.0"
@@ -39,6 +40,7 @@ androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "j
 junit-jupiter-api = { group = "org.junit.jupiter", name = "junit-jupiter-api", version.ref = "junit" }
 junit-jupiter-engine = { group = "org.junit.jupiter", name = "junit-jupiter-engine", version.ref = "junit" }
 junit-platform = { group = "org.junit.platform", name = "junit-platform-launcher" }
+turbineDependency-turbine = { group = "app.cash.turbine", name = "turbine", version.ref = "turbineVersion" }
 
 mockitoDependency-core = { group = "org.mockito", name = "mockito-core", version.ref = "mockitoVersion" }
 mockitoDependency-kotlin = { group = "org.mockito.kotlin", name = "mockito-kotlin", version.ref = "mockitoKotlinVersion" }


### PR DESCRIPTION
Fix current unit tests by verifying methods used in viewmodel init block. In IncomeModel and ExpanseModel remove default value of current time. Set current time for these models in viewmodel via time provider. Remove redundant dispatchers switch (in data store and room methods). Cover TransactionViewModel with unit tests.